### PR TITLE
Fix MongoDB auth and add admin user setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,26 @@ The services will be available at:
 - Admin UI: http://localhost:4200
 - MongoDB: localhost:27017
 
+4. Create an admin user:
+
+The first user you create will have the "user" role by default. To create an admin user, first register via the API:
+
+```bash
+curl -s -X POST http://localhost:8080/api/v1/auth/register \
+  -H "Content-Type: application/json" \
+  -d '{"email":"admin@lucidrag.dev","password":"admin123","name":"Admin User"}'
+```
+
+Then promote the user to admin in MongoDB:
+
+```bash
+docker exec lucidrag-mongodb-1 mongosh -u lucidrag -p lucidrag \
+  --authenticationDatabase admin lucidrag \
+  --eval 'db.users.updateOne({email:"admin@lucidrag.dev"},{$set:{role:"admin"}})'
+```
+
+Now you can log in at http://localhost:4200 with your admin credentials to access document management and conversation history.
+
 ### Local Development
 
 #### Backend (Go)

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -52,7 +52,7 @@ func main() {
 
 	ctx := context.Background()
 
-	mongoURI := fmt.Sprintf("mongodb://%s:%s@%s:%d/%s",
+	mongoURI := fmt.Sprintf("mongodb://%s:%s@%s:%d/%s?authSource=admin",
 		cfg.Database.User,
 		cfg.Database.Password,
 		cfg.Database.Host,


### PR DESCRIPTION
## Summary
- Fix MongoDB authentication by adding `authSource=admin` to connection string
- Add documentation for creating an admin user in the Quick Start guide

## Changes
- `cmd/api/main.go`: Add `?authSource=admin` to MongoDB URI for Docker Compose setup
- `README.md`: Add step 4 with curl command to register user and mongosh command to promote to admin

## Test plan
- [ ] Start services with `docker-compose up -d`
- [ ] Verify API connects to MongoDB (check `docker logs lucidrag-api-1`)
- [ ] Register admin user using documented curl command
- [ ] Promote user to admin using documented mongosh command
- [ ] Log in at http://localhost:4200 and verify admin access