### PR TITLE
Refactor auth from cookie-based to Bearer token only

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,8 +22,6 @@ RAG_CHUNK_OVERLAP=50
 # Authentication Configuration
 JWT_SECRET=your_jwt_secret_min_32_characters_here
 JWT_EXPIRY_HOURS=24
-COOKIE_DOMAIN=localhost
-COOKIE_SECURE=false
 
 # OAuth Configuration
 OAUTH_REDIRECT_BASE_URL=http://localhost:4200

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ go test ./internal/rag -v
 ### Angular Tests
 
 ```bash
-cd admin-ui
+cd ui
 npm test
 ```
 

--- a/README.md
+++ b/README.md
@@ -15,31 +15,43 @@ lucidRAG follows clean architecture principles with domain-driven design:
 ```
 lucidRAG/
 ├── cmd/
-│   └── api/              # Application entry points
-│       └── main.go       # Main server application
-├── internal/             # Private application code
-│   ├── config/          # Configuration management
-│   ├── domain/          # Domain models and interfaces
-│   ├── handler/         # HTTP request handlers
-│   ├── middleware/      # HTTP middleware
-│   ├── rag/            # RAG service implementation
-│   ├── repository/     # Data persistence layer
-│   ├── service/        # Business logic services
-│   └── whatsapp/       # WhatsApp API client
-├── pkg/                 # Public libraries
-│   └── logger/         # Logging utilities
-├── admin-ui/           # Angular admin dashboard
+│   └── api/                    # Application entry points
+│       └── main.go             # Main server application
+├── internal/                   # Private application code
+│   ├── application/           # Application services (business logic)
+│   │   ├── conversation/      # Conversation service
+│   │   ├── document/          # Document & RAG service
+│   │   ├── user/              # User service
+│   │   └── whatsapp/          # WhatsApp service
+│   ├── config/                # Configuration management
+│   ├── domain/                # Domain models and interfaces
+│   │   ├── conversation/      # Conversation domain
+│   │   ├── document/          # Document domain
+│   │   ├── system/            # System logs domain
+│   │   └── user/              # User domain
+│   ├── repository/            # Data persistence layer
+│   │   └── mongo/             # MongoDB implementations
+│   └── transport/             # Transport layer
+│       └── http/              # HTTP handlers & middleware
+│           ├── middleware/    # Auth, CORS, rate limiting
+│           └── v1/            # API v1 handlers
+├── pkg/                       # Public libraries
+│   ├── chunker/              # Document chunking
+│   ├── logger/               # Logging utilities
+│   └── openai/               # OpenAI client
+├── ui/                        # Angular frontend (main UI)
 │   ├── src/
 │   │   ├── app/
-│   │   │   ├── components/  # UI components
-│   │   │   ├── models/      # TypeScript interfaces
-│   │   │   └── services/    # API services
-│   │   └── environments/    # Environment configs
+│   │   │   ├── components/   # UI components
+│   │   │   ├── models/       # TypeScript interfaces
+│   │   │   └── services/     # API services
+│   │   └── assets/i18n/      # Translations (en, es, fr, de, pt, zh)
 │   └── Dockerfile
-├── .env.example        # Environment variables template
-├── Dockerfile          # Go API Dockerfile
-├── docker-compose.yml  # Docker Compose configuration
-├── Makefile           # Build automation
+├── .env.example              # Environment variables template
+├── API.md                    # API documentation
+├── Dockerfile                # Go API Dockerfile
+├── docker-compose.yml        # Docker Compose configuration
+├── Makefile                  # Build automation
 └── README.md
 ```
 
@@ -73,8 +85,8 @@ docker-compose up -d
 
 The services will be available at:
 - API: http://localhost:8080
-- Admin UI: http://localhost:4200
-- MongoDB: localhost:27017
+- Frontend UI: http://localhost:4200
+- MongoDB: localhost:27019
 
 ### Local Development
 
@@ -105,9 +117,9 @@ make test
 
 #### Frontend (Angular)
 
-1. Navigate to admin-ui directory:
+1. Navigate to ui directory:
 ```bash
-cd admin-ui
+cd ui
 ```
 
 2. Install dependencies:
@@ -121,6 +133,11 @@ npm start
 ```
 
 The Angular app will be available at http://localhost:4200
+
+**Features:**
+- Multi-language support (auto-detects browser language)
+- Dark/light theme with system preference detection
+- Responsive design with mobile support
 
 ## 🔧 Configuration
 
@@ -151,6 +168,13 @@ Key configuration options in `.env`:
 - `JWT_EXPIRY_HOURS`: Token expiry time in hours (default: 24)
 - `OPENAI_API_KEY`: OpenAI API key for embeddings and chat completion
 
+**OAuth Configuration (optional):**
+- `GOOGLE_OAUTH_ENABLED`: Enable Google OAuth (true/false)
+- `GOOGLE_CLIENT_ID`: Google OAuth client ID
+- `GOOGLE_CLIENT_SECRET`: Google OAuth client secret
+- `FACEBOOK_OAUTH_ENABLED`: Enable Facebook OAuth (true/false)
+- `APPLE_OAUTH_ENABLED`: Enable Apple Sign In (true/false)
+
 **Database Configuration (MongoDB):**
 - `DB_TYPE`: Database type (default: mongodb)
 - `DB_HOST`: Database host
@@ -169,10 +193,16 @@ GET /readyz               (Readiness check with DB status)
 
 ### Authentication API
 ```
-POST /api/v1/auth/register   (Register new user)
-POST /api/v1/auth/login      (Login and get JWT token)
-GET  /api/v1/auth/me         (Get current user - requires auth)
+POST /api/v1/auth/register           (Register new user)
+POST /api/v1/auth/login              (Login and get JWT token)
+GET  /api/v1/auth/me                 (Get current user - requires auth)
+GET  /api/v1/auth/oauth/providers    (List enabled OAuth providers)
+GET  /api/v1/auth/oauth/google       (Initiate Google OAuth)
+GET  /api/v1/auth/oauth/facebook     (Initiate Facebook OAuth)
+GET  /api/v1/auth/oauth/apple        (Initiate Apple Sign In)
 ```
+
+Authentication uses Bearer tokens. Include `Authorization: Bearer <token>` header for protected endpoints.
 
 ### WhatsApp Webhook
 ```
@@ -203,13 +233,15 @@ GET /api/v1/conversations/{id}/messages (Get conversation messages)
 
 ## 🎨 Frontend Features
 
-The Angular admin UI provides:
+The Angular UI provides:
 
-- **Authentication**: Login/Register with JWT-based authentication
+- **Authentication**: Login/Register with JWT-based authentication and OAuth social login
 - **Dashboard**: Overview of system status and features
 - **Document Management**: Upload, edit, and delete knowledge base documents
 - **Conversation History**: View WhatsApp conversations and RAG responses
-- **Responsive Design**: Works on desktop and mobile devices
+- **Internationalization**: Auto-detects browser language (EN, ES, FR, DE, PT, ZH)
+- **Theming**: Dark/light mode with system preference detection
+- **Responsive Design**: Works on desktop and mobile with gesture support
 
 ## 🧪 Testing
 
@@ -227,7 +259,7 @@ make lint
 
 ### Angular Tests
 ```bash
-cd admin-ui
+cd ui
 npm test
 ```
 
@@ -288,7 +320,7 @@ docker-compose build
 
 # Or build individually
 docker build -t lucidrag-api:latest .
-cd admin-ui && docker build -t lucidrag-ui:latest .
+cd ui && docker build -t lucidrag-ui:latest .
 ```
 
 ## 🤝 Contributing
@@ -312,7 +344,9 @@ For questions or issues, please open an issue on GitHub.
 - [x] Implement actual RAG query logic with embeddings
 - [x] Add user authentication and authorization
 - [x] Implement conversation history view
-- [ ] Add support for multiple languages
+- [x] Add support for multiple languages (i18n with auto-detection)
+- [x] Add OAuth social login (Google, Facebook, Apple)
+- [x] Add dark/light theme support
 - [ ] Implement analytics dashboard
 - [ ] Add file upload for documents (PDF, DOCX, etc.)
 - [ ] Implement vector database integration (Pinecone, Weaviate, etc.)

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -104,7 +104,7 @@ func main() {
 
 	v1 := r.Group("/api/v1")
 	authHandler.Register(v1, authHandler.NewHandler(userSvc, log), authMw)
-	authHandler.RegisterOAuth(v1, authHandler.NewOAuthHandler(userSvc, log, cfg.Auth.OAuth))
+	authHandler.RegisterOAuth(v1, authHandler.NewOAuthHandler(userSvc, log, cfg.Auth.OAuth, cfg.Auth.JWTSecret))
 	whatsappHandler.Register(v1, whatsappHdlr)
 	ragHandler.Register(v1.Group("/rag", authMw), ragHandler.NewHandler(documentSvc, log))
 	documentHandler.Register(v1.Group("/documents", authMw), documentHandler.NewHandler(documentSvc, log))

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -103,13 +103,8 @@ func main() {
 	})
 
 	v1 := r.Group("/api/v1")
-	cookieCfg := authHandler.CookieConfig{
-		Domain:      cfg.Auth.CookieDomain,
-		Secure:      cfg.Auth.CookieSecure,
-		ExpiryHours: cfg.Auth.JWTExpiryHours,
-	}
-	authHandler.Register(v1, authHandler.NewHandler(userSvc, log, cookieCfg), authMw)
-	authHandler.RegisterOAuth(v1, authHandler.NewOAuthHandler(userSvc, log, cfg.Auth.OAuth, cookieCfg))
+	authHandler.Register(v1, authHandler.NewHandler(userSvc, log), authMw)
+	authHandler.RegisterOAuth(v1, authHandler.NewOAuthHandler(userSvc, log, cfg.Auth.OAuth))
 	whatsappHandler.Register(v1, whatsappHdlr)
 	ragHandler.Register(v1.Group("/rag", authMw), ragHandler.NewHandler(documentSvc, log))
 	documentHandler.Register(v1.Group("/documents", authMw), documentHandler.NewHandler(documentSvc, log))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,8 +19,6 @@ type Config struct {
 type AuthConfig struct {
 	JWTSecret      string
 	JWTExpiryHours int
-	CookieDomain   string
-	CookieSecure   bool
 	OAuth          OAuthConfig
 }
 
@@ -110,8 +108,6 @@ func Load() (*Config, error) {
 		return nil, fmt.Errorf("invalid JWT_EXPIRY_HOURS: %w", err)
 	}
 
-	cookieSecure := getEnv("COOKIE_SECURE", "false") == "true"
-
 	config := &Config{
 		Server: ServerConfig{
 			Port:        port,
@@ -143,8 +139,6 @@ func Load() (*Config, error) {
 		Auth: AuthConfig{
 			JWTSecret:      getEnv("JWT_SECRET", ""),
 			JWTExpiryHours: jwtExpiry,
-			CookieDomain:   getEnv("COOKIE_DOMAIN", ""),
-			CookieSecure:   cookieSecure,
 			OAuth: OAuthConfig{
 				RedirectBaseURL: getEnv("OAUTH_REDIRECT_BASE_URL", "http://localhost:4200"),
 				Google: OAuthProviderConfig{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -152,26 +152,22 @@ func TestLoadOAuthDefaults(t *testing.T) {
 	}
 }
 
-func TestLoadCookieConfig(t *testing.T) {
+func TestLoadJWTConfig(t *testing.T) {
 	t.Setenv("DB_PASSWORD", "testpassword")
 	t.Setenv("WHATSAPP_WEBHOOK_VERIFY_TOKEN", "testtoken")
-	t.Setenv("COOKIE_DOMAIN", "example.com")
-	t.Setenv("COOKIE_SECURE", "true")
 	t.Setenv("JWT_EXPIRY_HOURS", "48")
+	t.Setenv("JWT_SECRET", "test-secret-key-min-32-characters")
 
 	cfg, err := Load()
 	if err != nil {
 		t.Fatalf("Failed to load config: %v", err)
 	}
 
-	if cfg.Auth.CookieDomain != "example.com" {
-		t.Errorf("Expected cookie domain example.com, got %s", cfg.Auth.CookieDomain)
-	}
-	if !cfg.Auth.CookieSecure {
-		t.Error("Expected cookie secure to be true")
-	}
 	if cfg.Auth.JWTExpiryHours != 48 {
 		t.Errorf("Expected JWT expiry hours 48, got %d", cfg.Auth.JWTExpiryHours)
+	}
+	if cfg.Auth.JWTSecret != "test-secret-key-min-32-characters" {
+		t.Errorf("Expected JWT secret to be set, got %s", cfg.Auth.JWTSecret)
 	}
 }
 

--- a/internal/transport/http/middleware/auth.go
+++ b/internal/transport/http/middleware/auth.go
@@ -8,33 +8,21 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-const cookieName = "lucidrag_token"
-
 func AuthMiddleware(userSvc userDomain.Service) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		var token string
-
-		// First, try to get token from cookie (primary method for browser clients)
-		if cookieToken, err := c.Cookie(cookieName); err == nil && cookieToken != "" {
-			token = cookieToken
-		}
-
-		// Fall back to Authorization header (for API clients)
-		if token == "" {
-			authHeader := c.GetHeader("Authorization")
-			if authHeader != "" {
-				parts := strings.Split(authHeader, " ")
-				if len(parts) == 2 && strings.ToLower(parts[0]) == "bearer" {
-					token = parts[1]
-				}
-			}
-		}
-
-		if token == "" {
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
+		authHeader := c.GetHeader("Authorization")
+		if authHeader == "" {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "authorization header required"})
 			return
 		}
 
+		parts := strings.Split(authHeader, " ")
+		if len(parts) != 2 || strings.ToLower(parts[0]) != "bearer" {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid authorization header format"})
+			return
+		}
+
+		token := parts[1]
 		claims, err := userSvc.ValidateToken(token)
 		if err != nil {
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid or expired token"})

--- a/internal/transport/http/v1/auth/oauth_handler_test.go
+++ b/internal/transport/http/v1/auth/oauth_handler_test.go
@@ -97,11 +97,6 @@ func createTestOAuthHandler(mockSvc *mockUserServiceOAuth) *OAuthHandler {
 				Enabled:    true,
 			},
 		},
-		CookieConfig{
-			Domain:      "localhost",
-			Secure:      false,
-			ExpiryHours: 24,
-		},
 	)
 }
 
@@ -148,7 +143,6 @@ func TestGetProvidersDisabled(t *testing.T) {
 			Facebook:        config.OAuthProviderConfig{Enabled: false},
 			Apple:           config.AppleOAuthConfig{Enabled: false},
 		},
-		CookieConfig{},
 	)
 
 	router := setupOAuthTestRouter()
@@ -181,7 +175,6 @@ func TestGoogleLoginDisabled(t *testing.T) {
 		config.OAuthConfig{
 			Google: config.OAuthProviderConfig{Enabled: false},
 		},
-		CookieConfig{},
 	)
 
 	router := setupOAuthTestRouter()
@@ -232,7 +225,6 @@ func TestFacebookLoginDisabled(t *testing.T) {
 		config.OAuthConfig{
 			Facebook: config.OAuthProviderConfig{Enabled: false},
 		},
-		CookieConfig{},
 	)
 
 	router := setupOAuthTestRouter()
@@ -278,7 +270,6 @@ func TestAppleLoginDisabled(t *testing.T) {
 		config.OAuthConfig{
 			Apple: config.AppleOAuthConfig{Enabled: false},
 		},
-		CookieConfig{},
 	)
 
 	router := setupOAuthTestRouter()

--- a/ui/src/app/app.ts
+++ b/ui/src/app/app.ts
@@ -1,7 +1,8 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { WatermarkComponent } from './components/shared/watermark/watermark';
 import { CookieConsentComponent } from './components/shared/cookie-consent/cookie-consent';
+import { LanguageService } from './services/language.service';
 
 @Component({
   selector: 'app-root',
@@ -13,4 +14,7 @@ import { CookieConsentComponent } from './components/shared/cookie-consent/cooki
     <app-cookie-consent></app-cookie-consent>
   `,
 })
-export class App {}
+export class App {
+  // Initialize language service early to detect browser language on app start
+  private languageService = inject(LanguageService);
+}

--- a/ui/src/app/services/language.service.ts
+++ b/ui/src/app/services/language.service.ts
@@ -34,16 +34,35 @@ export class LanguageService {
 
     // Get stored language or detect from browser
     const storedLang = localStorage.getItem(this.LANGUAGE_KEY);
-    const browserLang = this.translate.getBrowserLang();
 
-    let langCode = storedLang || browserLang || 'en';
-
-    // Ensure the language is supported
-    if (!this.languages.find(l => l.code === langCode)) {
-      langCode = 'en';
+    let langCode: string;
+    if (storedLang && this.languages.find(l => l.code === storedLang)) {
+      // Use stored language if valid
+      langCode = storedLang;
+    } else {
+      // Detect from browser
+      langCode = this.detectBrowserLanguage();
     }
 
     this.setLanguage(langCode);
+  }
+
+  private detectBrowserLanguage(): string {
+    // Get browser languages in order of preference
+    const browserLanguages = navigator.languages || [navigator.language];
+
+    for (const lang of browserLanguages) {
+      // Extract primary language code (e.g., 'en' from 'en-US')
+      const primaryCode = lang.split('-')[0].toLowerCase();
+
+      // Check if we support this language
+      if (this.languages.find(l => l.code === primaryCode)) {
+        return primaryCode;
+      }
+    }
+
+    // Default to English
+    return 'en';
   }
 
   setLanguage(code: string): void {


### PR DESCRIPTION
## Summary
- Remove `CookieConfig` struct and all cookie-based authentication logic
- Auth middleware now exclusively accepts `Authorization: Bearer <token>` header
- Login/Register endpoints return token in JSON response body instead of setting cookies
- Logout returns simple success message (client is responsible for discarding token)
- OAuth flow redirects with token as URL query parameter for frontend handling
- Update all auth tests to use Bearer token authentication

## Benefits
- Stateless authentication - no server-side session management needed
- Better suited for API-first architecture
- Simpler client implementation - just store token and send in header
- Works seamlessly with mobile apps and third-party integrations

## Test plan
- [x] All existing tests pass with Bearer token authentication
- [x] `go build ./...` succeeds
- [x] Manual verification of middleware rejecting requests without valid Bearer token